### PR TITLE
istio 세팅 및 테스트

### DIFF
--- a/istio/back-virtualservice.yaml
+++ b/istio/back-virtualservice.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: backend-vs
+  namespace: istio-system
+spec:
+  hosts:
+    - ab-back.back-a.svc.cluster.local
+  http:
+    - timeout: 5s
+      retries:
+        attempts: 3
+      route:
+        - destination:
+            host: ab-back.back-a.svc.cluster.local
+            port:
+              number: 3000

--- a/istio/canary-test.yaml
+++ b/istio/canary-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ab-back-dr
+  namespace: back-a
+spec:
+  host: ab-back.back-a.svc.cluster.local
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2
+---
+# 80% v1, 20% v2로 트래픽 분산
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ab-back-vs
+  namespace: back-a
+spec:
+  hosts:
+    - ab-back.back-a.svc.cluster.local
+  http:
+    - route:
+        - destination:
+            host: ab-back.back-a.svc.cluster.local
+            subset: v1
+          weight: 80
+        - destination:
+            host: ab-back.back-a.svc.cluster.local
+            subset: v2
+          weight: 20

--- a/istio/circuitbreaker.yaml
+++ b/istio/circuitbreaker.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ab-back-cb
+  namespace: back-a
+spec:
+  host: ab-back.back-a.svc.cluster.local
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 1   # 3번 연속 5xx 에러 시 차단
+      interval: 1s              # 10초마다 상태 체크
+      baseEjectionTime: 30s      # 30초 동안 차단
+      maxEjectionPercent: 50     # 최대 50% Pod 차단
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ab-back-vs
+  namespace: back-a
+spec:
+  hosts:
+    - ab-back.back-a.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: ab-back.back-a.svc.cluster.local
+        port:
+          number: 3000

--- a/istio/destinationrule.yaml
+++ b/istio/destinationrule.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: global-dr
+  namespace: istio-system
+spec:
+  host: "*.svc.cluster.local"
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http2MaxRequests: 1000
+    outlierDetection:               # Circuit Breaker
+      consecutive5xxErrors: 5       # 5xx 5번 연속 시
+      interval: 30s                 # 30초 간격으로 체크
+      baseEjectionTime: 30s         # 30초 동안 제외
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+

--- a/istio/front-virtualservice.yaml
+++ b/istio/front-virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: frontend
+  namespace: front
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - istio-system/msa-gateway
+  http:
+  - match:
+      - uri:
+          prefix: /
+    route:
+    - destination:
+        host: ab-front.front.svc.cluster.local
+        port:
+          number: 3001

--- a/istio/gateway.yaml
+++ b/istio/gateway.yaml
@@ -1,0 +1,16 @@
+# gateway.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: msa-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"

--- a/istio/mtls.yaml
+++ b/istio/mtls.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: mtls
+  namespace: istio-system
+spec:
+  mtls:
+    mode: STRICT

--- a/istio/recovery-test.yaml
+++ b/istio/recovery-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ab-back-vs
+  namespace: istio-system
+spec:
+  hosts:
+    - ab-back.back-a.svc.cluster.local
+  http:
+    - retries:
+        attempts: 3              # 3번 재시도
+        perTryTimeout: 2s        # 시도당 타임아웃
+        retryOn: 5xx,reset       # 5xx 에러, 연결 끊김 시 재시도
+      timeout: 10s
+      route:
+        - destination:
+            host: ab-back.back-a.svc.cluster.local
+            port:
+              number: 3000


### PR DESCRIPTION
## 구성

- Istio Ingress Gateway: 클러스터 외부 트래픽을 받는 진입점 역할
- VirtualService: 클라이언트가 호출하는 서비스들의 단일 진입점으로 요청하는 서비스로 라우팅 수행.
- mTLS: peerAuthentication 오브젝트 생성 시 strict 모드로 설정
- Circuit Breaker: DestinationRule에 정의된 라우팅 룰에 의해 트래픽 차단
- Kiali: 모니터링 대시보드. side-car 배포 확인 및 trace 추적 가능

<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/dc2c7698-caf3-459f-ac31-def0a9f70929" />
<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/bb1c41ed-4317-4649-815f-06c93615f477" />

---

## 테스트

### mTLS 테스트

```
# mTLS 적용 확인
istioctl x describe pod <ab-back-pod> -n backend

# 사이드카 없는 Pod에서 접근 차단 확인 (STRICT 모드)
kubectl run no-sidecar --image=curlimages/curl \
  -n default --restart=Never -- \
  curl http://ab-back.back-a.svc.cluster.local:3000
# 접근 차단되어야 정상

# 사이드카 있는 Pod에서 접근 허용 확인
kubectl run curl-test -n back-a --image=curlimages/curl \
  -it --rm --restart=Never -- sh

curl http://ab-back.back-a.svc.cluster.local:3000/messages
# 접근 허용되어야 정상
```

- mTLS를 적용하지 않은 파드

<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/811a64b7-3886-46aa-ab0b-898f5351c179" />

- default 네임스페이스에 위치한 파드는 istio가 비활성화 되어 있어 사이드카가 없으므로 트래픽을 받지 못함.

<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/59c1674b-d869-4d6d-aea2-6760ea2f4ace" />

</br>

- mTLS를 적용한 파드

<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/70faae41-ec20-4e34-b7e8-795cca788615" />

- istio가 활성화된 네임스페이스에 위치한 파드들은 정상적으로 통신

<img width="70%" height="auto" alt="Image" src="https://github.com/user-attachments/assets/0fa2d62b-eef4-4134-99a1-b595d3f77f53" />



